### PR TITLE
Text/en: fix typo

### DIFF
--- a/Text/en.txt
+++ b/Text/en.txt
@@ -20,7 +20,7 @@ Tram
 Railway station
 Railway stop
 Assign transport type to platform
-Shelder
+Shelter
 Bench
 Cover
 Area


### PR DESCRIPTION
turn "Shelder" into "Shelter" as seen on issue #4