### PR TITLE
updated plugin to support JOSM version 13265

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,9 +6,9 @@
 
     <property name="plugin.build.dir" value="build" />
     <property name="plugin.src.dir" value="src" />
-    <property name="plugin.dist.dir" value="../../dist" />
+    <property name="plugin.dist.dir" value="dist" />
     <property name="plugin.jar" value="${plugin.dist.dir}/CustomizePublicTransportStop.jar" />
-    <property name="josm" location="../../core/dist/josm-custom.jar"/>
+    <property name="josm" location="dist/josm-tested.jar"/>
 	
     <target name="init">
         <available file="build.properties" property="build.properties.present" />

--- a/src/ru/rodsoft/openstreetmap/josm/plugins/CustomizePublicTransportStop/CustomizePublicTransportStopPlugin.java
+++ b/src/ru/rodsoft/openstreetmap/josm/plugins/CustomizePublicTransportStop/CustomizePublicTransportStopPlugin.java
@@ -1,6 +1,6 @@
 package ru.rodsoft.openstreetmap.josm.plugins.customizepublictransportstop;
 
-import org.openstreetmap.josm.Main;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.plugins.Plugin;
 import org.openstreetmap.josm.plugins.PluginInformation;
 
@@ -24,7 +24,7 @@ public class CustomizePublicTransportStopPlugin  extends Plugin
     public CustomizePublicTransportStopPlugin(PluginInformation info) {
         super(info);
         stopAreaCreatorAction = CustomizeStopAction.createCustomizeStopAction();
-        Main.main.menu.toolsMenu.add(stopAreaCreatorAction);
+        MainApplication.getMenu().toolsMenu.add(stopAreaCreatorAction);
         System.out.println(getPluginDir());
     }
     

--- a/src/ru/rodsoft/openstreetmap/josm/plugins/CustomizePublicTransportStop/CustomizeStopAreaOperation.java
+++ b/src/ru/rodsoft/openstreetmap/josm/plugins/CustomizePublicTransportStop/CustomizeStopAreaOperation.java
@@ -273,7 +273,7 @@ public class CustomizeStopAreaOperation extends StopAreaOperationBase
 		{
 			newRelation.addMember(new RelationMember("", otherMember));
 		}
-		Main.main.undoRedo.add(new AddCommand(newRelation));
+		Main.main.undoRedo.add(new AddCommand(getCurrentDataSet(), newRelation));
 		commands = generalTagAssign(newRelation, commands, stopArea);
 		commands = assignTag(commands, newRelation, OSMTags.TYPE_TAG, OSMTags.PUBLIC_TRANSPORT_TAG);
 		commands = assignTag(commands, newRelation, OSMTags.PUBLIC_TRANSPORT_TAG, OSMTags.STOP_AREA_TAG_VALUE);
@@ -484,7 +484,7 @@ public class CustomizeStopAreaOperation extends StopAreaOperationBase
 			{
 				Node newNode =new Node();
 				newNode.setCoor(centerOfPlatform);
-		    	Main.main.undoRedo.add(new AddCommand(newNode));
+		    	Main.main.undoRedo.add(new AddCommand(getCurrentDataSet(), newNode));
 		    	Main.main.undoRedo.add(new ChangePropertyCommand(newNode, tag, tagValue));
 				commands = assignTag(commands, newNode, tag, tagValue);
 				stopArea.otherMembers.add(newNode);


### PR DESCRIPTION
With the latest JOSM plugin, a lot of [deprecated functions were eliminated](https://josm.openstreetmap.de/wiki/Changelog#stable-release-17.12). This PR fixes the files were deprecated functions were used to support compatibility with the newest JSON version.